### PR TITLE
Add ApiResponse wrapper class in dto for consistent response structure

### DIFF
--- a/app(backend)/src/main/java/com/knockoutzone/backend/dto/ApiResponse.java
+++ b/app(backend)/src/main/java/com/knockoutzone/backend/dto/ApiResponse.java
@@ -1,14 +1,13 @@
 package com.knockoutzone.backend.dto;
 
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
+@Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class ApiResponse<T> {
-
     private boolean success = true;
     private int statusCode = 200;
     private String message = null;

--- a/app(backend)/src/main/java/com/knockoutzone/backend/dto/ApiResponse.java
+++ b/app(backend)/src/main/java/com/knockoutzone/backend/dto/ApiResponse.java
@@ -1,0 +1,49 @@
+package com.knockoutzone.backend.dto;
+
+public class ApiResponse<T> {
+    private boolean success;
+    private int statusCode;
+    private String message;
+    private T data;
+
+    public ApiResponse() {}
+
+    public ApiResponse(boolean success, int statusCode, String message, T data) {
+        this.success = success;
+        this.statusCode = statusCode;
+        this.message = message;
+        this.data = data;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}

--- a/app(backend)/src/main/java/com/knockoutzone/backend/dto/ApiResponse.java
+++ b/app(backend)/src/main/java/com/knockoutzone/backend/dto/ApiResponse.java
@@ -1,49 +1,17 @@
 package com.knockoutzone.backend.dto;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class ApiResponse<T> {
-    private boolean success;
-    private int statusCode;
-    private String message;
-    private T data;
 
-    public ApiResponse() {}
-
-    public ApiResponse(boolean success, int statusCode, String message, T data) {
-        this.success = success;
-        this.statusCode = statusCode;
-        this.message = message;
-        this.data = data;
-    }
-
-    public boolean isSuccess() {
-        return success;
-    }
-
-    public void setSuccess(boolean success) {
-        this.success = success;
-    }
-
-    public int getStatusCode() {
-        return statusCode;
-    }
-
-    public void setStatusCode(int statusCode) {
-        this.statusCode = statusCode;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
-    public T getData() {
-        return data;
-    }
-
-    public void setData(T data) {
-        this.data = data;
-    }
+    private boolean success = true;
+    private int statusCode = 200;
+    private String message = null;
+    private T data = null;
 }
+


### PR DESCRIPTION
### **Pull Request: Add Generic API Response Wrapper**
 **Related Issue: #26** 

- _Description:_

As mentioned in issue #26, the backend required a generic API response wrapper class to ensure all controllers return consistent JSON structures. This enhances readability, reusability, and improves front-end integration by providing a standardized format across all endpoints.

- _What's Implemented:_

1. Created a generic ApiResponse<T> class inside the dto package.
2.Included the required fields:
         - success (boolean) – to indicate status
         - statusCode (int) – HTTP-style response code
         - -message (String) – a descriptive message
         - -data (T) – the actual response data (generic)
3.Constructor overloads and getter/setter methods for ease of use.
4.Ready to be integrated across all controllers.


- _Status:_

1. Code added without breaking changes.
2.Compiled successfully (verified via ./mvnw clean install)
3. PR ready for review.
4. Fixes and closes issue #26

Let me know if any changes are needed. Thank  @Ayush0316  for the opportunity 🙌😊